### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## Install
 
 ```sh
-sudo add-apt-repository ppa:atareao\atareao
+sudo add-apt-repository ppa:atareao/atareao
 sudo apt update
 sudo apt install calendar-indicator
 ```


### PR DESCRIPTION
sudo add-apt-repository ppa:atareao\atareao   trigger following error: 
Cannot add PPA: 'ppa:~atareaoatareao/ubuntu/ppa'.
ERROR: '~atareaoatareao' user or team does not exist.

You should use Slash (/) instead of Backslash(\) 
fix: sudo add-apt-repository ppa:atareao/atareao